### PR TITLE
Add xmlns definition to FileIcon

### DIFF
--- a/src/components/FileIcon.js
+++ b/src/components/FileIcon.js
@@ -90,6 +90,7 @@ export const FileIcon = ({
 
   return (
     <svg
+      xmlns="http://www.w3.org/2000/svg"
       viewBox={`0 0 ${VIEWBOX.WIDTH} ${VIEWBOX.HEIGHT}`}
       width={size}
       height={size}


### PR DESCRIPTION
Hey,

I wanted to encode generated `svg` from `FileIcon` as background-image CSS property, but it wouldn't render at all. After some searching I stumbled upon this SO answer - https://stackoverflow.com/a/28379733

For whatever reason, the initial <svg> tag needs to have `xmlns` attribute defined to be used in this way - I tried it and it indeed works. So that's what this PR is about. Thanks :)