### PR TITLE
Remove labelUppercase prop

### DIFF
--- a/src/FileIcon.js
+++ b/src/FileIcon.js
@@ -24,8 +24,6 @@ const propTypes = {
   labelColor: PropTypes.string,
   /** Color of label text */
   labelTextColor: PropTypes.string,
-  /** Displays the label in all caps */
-  labelUppercase: PropTypes.bool,
   /** Corner radius of the file icon */
   radius: PropTypes.number,
   /** Type of glyph icon to display */
@@ -76,7 +74,6 @@ export const FileIcon = ({
   gradientOpacity = 0.25,
   labelColor,
   labelTextColor = 'white',
-  labelUppercase = false,
   radius = 4,
   type,
 }) => {
@@ -200,7 +197,6 @@ export const FileIcon = ({
                 fontWeight: 'bold',
                 textAlign: 'center',
                 pointerEvents: 'none',
-                textTransform: labelUppercase ? 'uppercase' : 'none',
                 userSelect: 'none',
               }}
             >


### PR DESCRIPTION
Seems unnecessary since the text can be formatted before setting the `extension` prop.