### PR TITLE
Moving to colord package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "colord": "^2.9.3",
     "lodash.uniqueid": "^4.0.1",
-    "prop-types": "^15.7.2",
-    "tinycolor2": "^1.4.2"
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",

--- a/src/FileIcon.js
+++ b/src/FileIcon.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import tinycolor from 'tinycolor2';
+import { colord, extend as extendColord } from 'colord';
+import namesPlugin from 'colord/plugins/names';
 import uniqueId from 'lodash.uniqueid';
 
 import glyphs from './glyphs';
+
+extendColord([namesPlugin]);
 
 const propTypes = {
   /** Color of icon background */
@@ -168,7 +171,7 @@ export const FileIcon = ({
           <rect
             width={ICON.WIDTH}
             height={ICON.HEIGHT}
-            fill={foldColor || tinycolor(color).darken(10).toString()}
+            fill={foldColor || colord(color).darken(0.1).toString()}
             rx={radius}
             ry={radius}
             clipPath="url(#foldCrop)"
@@ -180,7 +183,7 @@ export const FileIcon = ({
         <React.Fragment>
           <g id="label">
             <rect
-              fill={labelColor || tinycolor(color).darken(30).toString()}
+              fill={labelColor || colord(color).darken(0.3).toString()}
               x={ICON.X_OFFSET}
               y={ICON.HEIGHT - LABEL_HEIGHT}
               width={ICON.WIDTH}
@@ -213,7 +216,7 @@ export const FileIcon = ({
       {type && (
         <g
           transform={`translate(-4 ${!extension ? 6 : 0})`}
-          fill={glyphColor || tinycolor(color).darken(15).toString()}
+          fill={glyphColor || colord(color).darken(0.15).toString()}
         >
           {glyphs[type]}
         </g>

--- a/src/FileIcon.js
+++ b/src/FileIcon.js
@@ -171,7 +171,7 @@ export const FileIcon = ({
           <rect
             width={ICON.WIDTH}
             height={ICON.HEIGHT}
-            fill={foldColor || colord(color).darken(0.1).toString()}
+            fill={foldColor || colord(color).darken(0.1).toHex()}
             rx={radius}
             ry={radius}
             clipPath="url(#foldCrop)"
@@ -183,7 +183,7 @@ export const FileIcon = ({
         <React.Fragment>
           <g id="label">
             <rect
-              fill={labelColor || colord(color).darken(0.3).toString()}
+              fill={labelColor || colord(color).darken(0.3).toHex()}
               x={ICON.X_OFFSET}
               y={ICON.HEIGHT - LABEL_HEIGHT}
               width={ICON.WIDTH}
@@ -216,7 +216,7 @@ export const FileIcon = ({
       {type && (
         <g
           transform={`translate(-4 ${!extension ? 6 : 0})`}
-          fill={glyphColor || colord(color).darken(0.15).toString()}
+          fill={glyphColor || colord(color).darken(0.15).toHex()}
         >
           {glyphs[type]}
         </g>

--- a/src/__tests__/__snapshots__/FileIcon.test.js.snap
+++ b/src/__tests__/__snapshots__/FileIcon.test.js.snap
@@ -77,7 +77,7 @@ exports[`<FileIcon /> border radius variations render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={0}
         ry={0}
@@ -153,7 +153,7 @@ exports[`<FileIcon /> border radius variations render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={2}
         ry={2}
@@ -229,7 +229,7 @@ exports[`<FileIcon /> border radius variations render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -305,7 +305,7 @@ exports[`<FileIcon /> border radius variations render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={6}
         ry={6}
@@ -381,7 +381,7 @@ exports[`<FileIcon /> border radius variations render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={8}
         ry={8}
@@ -457,7 +457,7 @@ exports[`<FileIcon /> border radius variations render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={10}
         ry={10}
@@ -589,7 +589,7 @@ exports[`<FileIcon /> color variations render correctly 1`] = `
       </text>
     </g>
     <g
-      fill="#ff9f94"
+      fill="#ff9f95"
       transform="translate(-4 0)"
     >
       <path
@@ -711,7 +711,7 @@ exports[`<FileIcon /> color variations render correctly 1`] = `
       </text>
     </g>
     <g
-      fill="#ffd288"
+      fill="#ffd289"
       transform="translate(-4 0)"
     >
       <path
@@ -833,7 +833,7 @@ exports[`<FileIcon /> color variations render correctly 1`] = `
       </text>
     </g>
     <g
-      fill="#ffe98f"
+      fill="#ffe990"
       transform="translate(-4 0)"
     >
       <path
@@ -955,7 +955,7 @@ exports[`<FileIcon /> color variations render correctly 1`] = `
       </text>
     </g>
     <g
-      fill="#e4e4a0"
+      fill="#e4e4a1"
       transform="translate(-4 0)"
     >
       <path
@@ -1077,7 +1077,7 @@ exports[`<FileIcon /> color variations render correctly 1`] = `
       </text>
     </g>
     <g
-      fill="#a3d4ff"
+      fill="#a4d4ff"
       transform="translate(-4 0)"
     >
       <path
@@ -1155,7 +1155,7 @@ exports[`<FileIcon /> color variations render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#bbbbf1"
+        fill="#bbbbf2"
         height={48}
         rx={4}
         ry={4}
@@ -1167,7 +1167,7 @@ exports[`<FileIcon /> color variations render correctly 1`] = `
     >
       <rect
         clipPath="url(#pageRadius17)"
-        fill="#6666e0"
+        fill="#6666e1"
         height={14}
         width={40}
         x={0}
@@ -1289,7 +1289,7 @@ exports[`<FileIcon /> file type glyphs render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -1375,7 +1375,7 @@ exports[`<FileIcon /> file type glyphs render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -1461,7 +1461,7 @@ exports[`<FileIcon /> file type glyphs render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -1547,7 +1547,7 @@ exports[`<FileIcon /> file type glyphs render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -1633,7 +1633,7 @@ exports[`<FileIcon /> file type glyphs render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -1719,7 +1719,7 @@ exports[`<FileIcon /> file type glyphs render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -1805,7 +1805,7 @@ exports[`<FileIcon /> file type glyphs render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -1891,7 +1891,7 @@ exports[`<FileIcon /> file type glyphs render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -1977,7 +1977,7 @@ exports[`<FileIcon /> file type glyphs render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -2063,7 +2063,7 @@ exports[`<FileIcon /> file type glyphs render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -2149,7 +2149,7 @@ exports[`<FileIcon /> file type glyphs render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -2235,7 +2235,7 @@ exports[`<FileIcon /> file type glyphs render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -2321,7 +2321,7 @@ exports[`<FileIcon /> file type glyphs render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -2407,7 +2407,7 @@ exports[`<FileIcon /> file type glyphs render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -2493,7 +2493,7 @@ exports[`<FileIcon /> file type glyphs render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -2590,7 +2590,7 @@ exports[`<FileIcon /> label colors render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -2702,7 +2702,7 @@ exports[`<FileIcon /> label colors render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -2814,7 +2814,7 @@ exports[`<FileIcon /> label colors render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -2926,7 +2926,7 @@ exports[`<FileIcon /> label colors render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -3038,7 +3038,7 @@ exports[`<FileIcon /> label colors render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -3150,7 +3150,7 @@ exports[`<FileIcon /> label colors render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -3274,7 +3274,7 @@ exports[`<FileIcon /> renders uppercase label when labelUppercase is true 1`] = 
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -3286,7 +3286,7 @@ exports[`<FileIcon /> renders uppercase label when labelUppercase is true 1`] = 
     >
       <rect
         clipPath="url(#pageRadius48)"
-        fill="#a8a8a8"
+        fill="#a9a9a9"
         height={14}
         width={40}
         x={0}
@@ -3468,7 +3468,7 @@ exports[`<FileIcon /> standard arrangements render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -3544,7 +3544,7 @@ exports[`<FileIcon /> standard arrangements render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -3630,7 +3630,7 @@ exports[`<FileIcon /> standard arrangements render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -3642,7 +3642,7 @@ exports[`<FileIcon /> standard arrangements render correctly 1`] = `
     >
       <rect
         clipPath="url(#pageRadius4)"
-        fill="#a8a8a8"
+        fill="#a9a9a9"
         height={14}
         width={40}
         x={0}
@@ -3742,7 +3742,7 @@ exports[`<FileIcon /> standard arrangements render correctly 1`] = `
     >
       <rect
         clipPath="url(#foldCrop)"
-        fill="#dbdbdb"
+        fill="#dcdcdc"
         height={48}
         rx={4}
         ry={4}
@@ -3754,7 +3754,7 @@ exports[`<FileIcon /> standard arrangements render correctly 1`] = `
     >
       <rect
         clipPath="url(#pageRadius5)"
-        fill="#a8a8a8"
+        fill="#a9a9a9"
         height={14}
         width={40}
         x={0}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1957,6 +1957,11 @@ color@^3.0.0:
     color-convert "^1.9.3"
     color-string "^1.6.0"
 
+colord@^2.9.3:
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.3.tgz#4f8ce919de456f1d5c1c368c307fe20f3e59fb43"
+  integrity sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==
+
 colorette@^1.2.1, colorette@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
@@ -5912,11 +5917,6 @@ tiny-glob@^0.2.6:
   dependencies:
     globalyzer "0.1.0"
     globrex "^0.1.2"
-
-tinycolor2@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.2.tgz#3f6a4d1071ad07676d7fa472e1fac40a719d8803"
-  integrity sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
## Moving away from `tinycolor2` in favor of `colord` to reduce package size.

### Note 1: The `darken` function now takes a value between `0 and 1` instead of between `0 and 100`
https://www.npmjs.com/package/tinycolor2#darken
https://www.npmjs.com/package/colord

## Note 2: Color calculations resulted in very negligible changes (imo):

![image](https://user-images.githubusercontent.com/8313853/207931083-f1790162-66e3-431e-834c-b4546034c370.png)

Note also that if I say `darken(0.15001)` instead of `darken(0.15)` for example, the tests pass, but this feels dirty, and I would rather update the snapshots personally.